### PR TITLE
Add GitHub templates and PlatformIO CI workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,101 @@
+name: Bug report
+description: Report a bug, defect, or unexpected behavior in the GPS clock
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug report. Please fill out the sections below so we can reproduce and investigate.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: A clear and concise description of the bug.
+      placeholder: "When GPS is connected, the clock shows..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce this issue?
+      placeholder: |
+        1. Power on the clock
+        2. Wait for GPS lock
+        3. Observe ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: I expected the clock to show...
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Instead, the clock showed...
+    validations:
+      required: true
+
+  - type: dropdown
+    id: environment
+    attributes:
+      label: Where did you observe this?
+      options:
+        - Real hardware (Arduino Nano + GPS)
+        - Wokwi simulator
+        - Both
+    validations:
+      required: true
+
+  - type: input
+    id: gps-module
+    attributes:
+      label: GPS module
+      description: Which GPS module are you using? (e.g. NEO-6M, NEO-7M, NEO-M8N)
+      placeholder: NEO-6M
+
+  - type: input
+    id: firmware-version
+    attributes:
+      label: Firmware version / commit
+      description: Output of `git rev-parse --short HEAD` or release tag
+      placeholder: e.g. b8bfb72 or v1.0.0
+
+  - type: input
+    id: timezone
+    attributes:
+      label: Timezone configured
+      description: Value of TIMEZONE_OFFSET_HOURS / TIMEZONE_OFFSET_MINUTES in src/config.h
+      placeholder: e.g. +5:30 (IST)
+
+  - type: textarea
+    id: serial-log
+    attributes:
+      label: Serial monitor output
+      description: If ENABLE_SERIAL_DEBUG is true, paste relevant serial output here.
+      render: shell
+
+  - type: textarea
+    id: photos
+    attributes:
+      label: Photos / video
+      description: Attach a photo or short video of the LED matrix if visual.
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues and did not find a duplicate
+          required: true
+        - label: I am running the latest commit on master
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions and discussions
+    url: https://github.com/zeevy/gps-led-clock/discussions
+    about: Have a question, need help wiring it up, or want to share your build? Start a discussion.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,63 @@
+name: Feature request
+description: Suggest a new feature or enhancement for the GPS clock
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for suggesting an enhancement! Keep in mind this project targets an Arduino Nano (2KB SRAM, 32KB flash) and a fixed 32x8 LED matrix.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What problem does this feature solve? Why is it valuable?
+      placeholder: "Currently the clock cannot..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Describe what you want to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you have thought about.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      options:
+        - Display / animation
+        - GPS / time handling
+        - Configuration / EEPROM
+        - Power / brightness
+        - Wokwi simulator
+        - Documentation
+        - Other
+    validations:
+      required: true
+
+  - type: textarea
+    id: hardware
+    attributes:
+      label: Hardware impact
+      description: Does this require new components, more memory, different pins, etc.?
+
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Pre-submission checks
+      options:
+        - label: I searched existing issues / discussions and did not find a duplicate
+          required: true
+        - label: I have considered the Arduino Nano memory constraints (2KB SRAM, 32KB flash)
+          required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,50 @@
+## Summary
+
+<!-- What does this PR change and why? Keep it to a few sentences. -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Refactor / cleanup (no functional change)
+- [ ] Documentation / chore
+
+## Hardware impact
+
+<!-- Does this affect wiring, pin assignments, or supported hardware? -->
+
+- [ ] No hardware impact
+- [ ] Pin assignments changed (update README and config.h)
+- [ ] New module / sensor / library added
+- [ ] Memory footprint changed significantly (note RAM/Flash deltas below)
+
+## Test plan
+
+<!-- How was this verified? Check all that apply. -->
+
+- [ ] Builds clean with `pio run`
+- [ ] Tested in Wokwi simulator (`wokwi.toml` / `diagram.json`)
+- [ ] Tested on real Arduino Nano + GPS hardware
+- [ ] Time display verified (12H and 24H formats)
+- [ ] Date display verified
+- [ ] GPS location display verified
+- [ ] Rain effect / GPS-loss fallback verified
+- [ ] Brightness day/night transition verified
+
+## Memory footprint (if changed)
+
+<!-- Paste `pio run` output showing RAM/Flash usage before and after. -->
+
+```
+Before: RAM:  ___ /2048 bytes   Flash: _____ /32256 bytes
+After:  RAM:  ___ /2048 bytes   Flash: _____ /32256 bytes
+```
+
+## Related issues
+
+<!-- Link any related issues, e.g. "Closes #12" -->
+
+## Screenshots / video (optional)
+
+<!-- Drag and drop images or video showing the change on the matrix. -->

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,47 @@
+name: PlatformIO Build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build firmware (nanoatmega328)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.cache/pip
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+
+      - name: Build
+        run: pio run
+
+      - name: Upload firmware artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: firmware-nanoatmega328
+          path: .pio/build/nanoatmega328/firmware.hex
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,15 +14,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
       - name: Cache PlatformIO
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.platformio/.cache
@@ -40,7 +40,7 @@ jobs:
         run: pio run
 
       - name: Upload firmware artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: firmware-nanoatmega328
           path: .pio/build/nanoatmega328/firmware.hex


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/build.yml` that runs `pio run` on push/PR to master, caches PlatformIO, and uploads the firmware `.hex` as an artifact
- Adds PR template tailored to this project (hardware impact, memory footprint, Wokwi + real-hardware test plan)
- Adds issue templates: bug report (with GPS module / timezone / serial log fields) and feature request (with Arduino Nano memory-constraint reminder)
- Routes questions/help requests to Discussions via `ISSUE_TEMPLATE/config.yml`

## Type of change

- [x] Documentation / chore

## Hardware impact

- [x] No hardware impact

## Test plan

- [x] Builds clean with `pio run` (the new workflow will verify this on CI)
- [ ] Verify Actions tab shows the workflow running on this PR
- [ ] Verify firmware artifact is uploaded
- [ ] Verify PR/issue templates render correctly when opening new issues/PRs