### PR TITLE
Add release workflow that publishes firmware on v* tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,110 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Cache PlatformIO
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.platformio/.cache
+            ~/.cache/pip
+          key: ${{ runner.os }}-pio-${{ hashFiles('platformio.ini') }}
+          restore-keys: |
+            ${{ runner.os }}-pio-
+
+      - name: Install PlatformIO
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade platformio
+
+      - name: Build firmware
+        run: pio run
+
+      - name: Stage release artifacts
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          mkdir -p release
+          cp .pio/build/nanoatmega328/firmware.hex "release/gps-led-clock-${TAG}.hex"
+          cp .pio/build/nanoatmega328/firmware.elf "release/gps-led-clock-${TAG}.elf"
+          ls -lh release/
+
+      - name: Build release notes
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          PREV_TAG=$(git tag --sort=-v:refname | grep -v "^${TAG}$" | head -n1 || true)
+          {
+            echo "## Flashing instructions"
+            echo
+            echo "Download \`gps-led-clock-${TAG}.hex\` below and flash to an Arduino Nano (ATmega328P)."
+            echo
+            echo "**Disconnect the GPS module's TX from Arduino pin 0 (RX0) before flashing**, otherwise the upload will fail because GPS shares the hardware UART."
+            echo
+            echo "### avrdude (CLI)"
+            echo
+            echo '```'
+            echo "avrdude -c arduino -p atmega328p -P /dev/ttyUSB0 -b 115200 -U flash:w:gps-led-clock-${TAG}.hex"
+            echo '```'
+            echo
+            echo "Use \`-b 57600\` if your Nano has the older bootloader. Replace \`/dev/ttyUSB0\` with your serial port (\`/dev/tty.usbserial-*\` on macOS, \`COM3\` etc. on Windows)."
+            echo
+            echo "### Arduino IDE"
+            echo
+            echo "1. Set Board to *Arduino Nano*, Processor to *ATmega328P* (or *ATmega328P (Old Bootloader)* for older boards)."
+            echo "2. *Sketch > Upload Using Programmer* with the downloaded \`.hex\`."
+            echo
+            echo "### xLoader / AVRDUDESS (Windows GUI)"
+            echo
+            echo "Select the \`.hex\` file, device *ATmega328*, baud *115200* (or *57600* for old bootloader)."
+            echo
+            echo "## Artifacts"
+            echo
+            echo "- \`gps-led-clock-${TAG}.hex\` - flash image (use this for normal flashing)"
+            echo "- \`gps-led-clock-${TAG}.elf\` - executable with symbols (for debugging or \`avr-objdump\`)"
+            echo
+            if [ -n "$PREV_TAG" ]; then
+              echo "## Changes since ${PREV_TAG}"
+              echo
+              git log "${PREV_TAG}..${TAG}" --pretty=format:'- %s' --no-merges
+              echo
+            fi
+          } > release-notes.md
+          cat release-notes.md
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF_NAME}"
+          if [[ "$TAG" == *-* ]]; then
+            PRERELEASE_FLAG="--prerelease"
+          else
+            PRERELEASE_FLAG=""
+          fi
+          gh release create "$TAG" \
+            "release/gps-led-clock-${TAG}.hex" \
+            "release/gps-led-clock-${TAG}.elf" \
+            --title "$TAG" \
+            --notes-file release-notes.md \
+            $PRERELEASE_FLAG


### PR DESCRIPTION
## Summary

Adds \`.github/workflows/release.yml\`. Pushing a tag matching \`v*\` builds the firmware and creates a GitHub Release with the compiled \`.hex\` and \`.elf\` attached, plus a body with flashing instructions and a changelog.

## How to use

```bash
git tag v1.0.0
git push origin v1.0.0
```

That's it. The workflow then:
1. Builds firmware with PlatformIO
2. Stages \`gps-led-clock-v1.0.0.hex\` and \`gps-led-clock-v1.0.0.elf\`
3. Generates release notes (flashing instructions + auto-changelog of commits since previous tag)
4. Creates a GitHub Release with both files attached

## Design choices

- **Trigger**: \`push\` on \`tags: ['v*']\`. Matches \`v1.0.0\`, \`v0.2\`, \`v1.0.0-rc1\`, etc.
- **Prerelease detection**: any tag with a dash (\`v1.0.0-rc1\`, \`v1.0.0-beta\`) is auto-marked as a GitHub prerelease.
- **No third-party actions**: uses the preinstalled \`gh\` CLI for release creation instead of \`softprops/action-gh-release\` or similar, so there's no supply-chain dependency for releases.
- **Artifacts**: \`.hex\` is the primary flash image. \`.elf\` is included for symbol-aware debugging (\`avr-objdump\`, \`avr-gdb\`).
- **Cache**: shares the same PlatformIO cache key as \`build.yml\`, so release runs warm-start from the regular CI cache.
- **Permissions**: \`contents: write\` only (needed for release creation; nothing else).
- **Flashing instructions** in the release body cover avrdude (CLI), Arduino IDE, and xLoader/AVRDUDESS (Windows GUI), plus the GPS-TX-disconnect warning since it shares the hardware UART.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Hardware impact

- [x] No hardware impact

## Test plan

- [ ] Merge this PR
- [ ] Tag and push: \`git tag v0.1.0 && git push origin v0.1.0\`
- [ ] Verify the Release workflow runs in Actions, creates a Release at \`/releases/tag/v0.1.0\`, attaches both files, and renders the flashing instructions in the body
- [ ] Download \`gps-led-clock-v0.1.0.hex\` and confirm it flashes successfully to a real Arduino Nano