### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
     branches: [master]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build firmware (nanoatmega328)


### PR DESCRIPTION
Potential fix for [https://github.com/zeevy/gps-led-clock/security/code-scanning/1](https://github.com/zeevy/gps-led-clock/security/code-scanning/1)

Add an explicit `permissions` block at the workflow root so all jobs inherit minimal required access. For this workflow, `contents: read` is the correct minimal baseline and preserves existing functionality (checkout can read repository contents; artifact upload does not require repository write scopes).  
Edit **`.github/workflows/build.yml`** by inserting:

```yml
permissions:
  contents: read
```

directly after the `on:` triggers section (before `jobs:`), or alternatively under the `build` job. Root-level is cleaner and future-proof for additional jobs unless specific jobs need overrides.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
